### PR TITLE
changed config for upload to IPFS (static build)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+    reactStrictMode: true,
+    images: {
+        loader: "akamai",
+        path: "",
+    },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
I changed the default image loader to "akamai" in next.config.js as it is known to render images without help from server (client-side rendering).
I have been using this method and it's very easy and simple as no code change is required, except an addition to the config file.

I have hosted my website at: 
ipfs://QmQKJRcqvYSCnt9YzSVdXcjpyrkW47cT9HYDhf1Tmw3KHL

or

nft-marketplace.arpit-singh.me

Both of which can only deploy a static website and my website is working very fine as of now, with images rendering as expected.

If I am still eligible for an NFT gift, for which I really appreciate @PatrickAlphaC for such innovative, here is my address:
0x513417e1393a08b6E9D882cafE191086F131d7E1
or
arpitsingh.eth