### PR TITLE
Remove wrapping div

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -24,16 +24,14 @@ export default function Home() {
                             console.log(nft)
                             const { price, nftAddress, tokenId, seller } = nft
                             return (
-                                <div>
-                                    <NFTBox
-                                        price={price}
-                                        nftAddress={nftAddress}
-                                        tokenId={tokenId}
-                                        marketplaceAddress={marketplaceAddress}
-                                        seller={seller}
-                                        key={`${nftAddress}${tokenId}`}
-                                    />
-                                </div>
+                                <NFTBox
+                                    price={price}
+                                    nftAddress={nftAddress}
+                                    tokenId={tokenId}
+                                    marketplaceAddress={marketplaceAddress}
+                                    seller={seller}
+                                    key={`${nftAddress}${tokenId}`}
+                                />
                             )
                         })
                     )


### PR DESCRIPTION
By removing the wrapping div you get rid of the error in the browser console that says:

```
Warning: Each child in a list should have a unique "key" prop.