### PR TITLE
Update the buyer address

### DIFF
--- a/constants/subgraphQueries.js
+++ b/constants/subgraphQueries.js
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client"
 
 const GET_ACTIVE_ITEMS = gql`
     {
-        activeItems(first: 5, where: { buyer: "0x00000000" }) {
+        activeItems(first: 5, where: { buyer: "0x0000000000000000000000000000000000000000" }) {
             id
             buyer
             seller

--- a/pages/graphExample.js
+++ b/pages/graphExample.js
@@ -2,7 +2,7 @@ import { useQuery, gql } from "@apollo/client"
 
 const GET_ACTIVE_ITEMS = gql`
     {
-        activeItems(first: 5, where: { buyer: "0x00000000" }) {
+        activeItems(first: 5, where: { buyer: "0x0000000000000000000000000000000000000000" }) {
             id
             buyer
             seller


### PR DESCRIPTION
In the graphql repo code we are saving this address for the buyer:

```js
activeItem.buyer = Address.fromString("0x0000000000000000000000000000000000000000")
```
Due to that, this GraphQL query returns nothing:

```js
  {
      activeItems(first: 5, where: { buyer: "0x00000000" }) {
          id
          buyer
          seller
          nftAddress
          tokenId
          price
      }
  }
```
I have updated this to both these files `graphExample.js` & `subgraphQueries.js`

```js
const GET_ACTIVE_ITEMS = gql`
    {
        activeItems(first: 5, where: { buyer: "0x0000000000000000000000000000000000000000" }) {
            id
            buyer
            seller
            nftAddress
            tokenId
            price
        }
    }
`
```