### PR TITLE
Fixed: Waiting for approve tx

### DIFF
--- a/pages/sell-nft.js
+++ b/pages/sell-nft.js
@@ -36,7 +36,7 @@ export default function Home() {
 
         await runContractFunction({
             params: approveOptions,
-            onSuccess: () => handleApproveSuccess(nftAddress, tokenId, price),
+            onSuccess: (tx) => handleApproveSuccess(tx, nftAddress, tokenId, price),
             onError: (error) => {
                 console.log(error)
             },
@@ -45,6 +45,7 @@ export default function Home() {
 
     async function handleApproveSuccess(nftAddress, tokenId, price) {
         console.log("Ok! Now time to list")
+        await tx.wait()
         const listOptions = {
             abi: nftMarketplaceAbi,
             contractAddress: marketplaceAddress,


### PR DESCRIPTION
## Description
List NFT transaction getting failed at estimating gas fee because it doesn't wait for approval.

## Details
When using Testnet and send approve transaction,
The approve transaction is sent  from metamask,
handleApproveSuccess is automatically called which run the second runContractFunction before waiting for approve tx to get confirmed in result the listItem tx fails

## Changes Made

    await runContractFunction({
        params: approveOptions,
        onSuccess: (tx) => handleApproveSuccess(tx, nftAddress, tokenId, price),    //passed tx to handler
        onError: (error) => {
        console.log(error)
        },
    })

    async function handleApproveSuccess(nftAddress, tokenId, price) {
        console.log("Ok! Now time to list")
        await tx.wait()         // waited for tx to confirm
        const listOptions = {
            abi: nftMarketplaceAbi,
            contractAddress: marketplaceAddress,
            functionName: "listItem",
            params: {
                nftAddress: nftAddress,
                tokenId: tokenId,
                price: price,
            },
        }


